### PR TITLE
Fix the lookup for mat

### DIFF
--- a/structure.js
+++ b/structure.js
@@ -87,7 +87,7 @@ var people = [
             "bugzilla_nick": "kumar",
             "github": "kumar303"
         },
-        "mat": {
+        "mpillard": {
             "timezone": "Europe/Paris",
             "image": "https://phonebook.mozilla.org//pic.php?mail=mpillard@mozilla.com&type=thumb",
             "irc": "mat",


### PR DESCRIPTION
The key to find a person uses the bugzilla_nick but mat's key doesn't match his bugzilla_nick so he gets an empty list of people.